### PR TITLE
feat: Add support for Android 12 and build on VS2022

### DIFF
--- a/BiometryService.sln
+++ b/BiometryService.sln
@@ -205,6 +205,7 @@ Global
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iOS.ActiveCfg = Debug|iPhoneSimulator
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iPhone.Build.0 = Debug|iPhone
+		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{2B4DC5A4-BFD3-4C27-9BF9-51C2015926E4}.Debug|NuGet.ActiveCfg = Debug|iPhoneSimulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
 
 ### Changed
 [#52] Change target Uno.UI version to 4.0.7
 ### Deprecated
 
 ### Removed
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 
 ### Fixed
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,13 +7,13 @@ trigger:
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
   value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 17.1.0
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -31,7 +31,7 @@ variables:
 - name:  InternalKeystore
   value: com.nventive.internal.applicationtemplate.jks
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.3.0
+next-version: 0.4.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/BiometryService.SampleApp.Uno/BiometryService.SampleApp.Uno.Droid/BiometryService.SampleApp.Uno.Droid.csproj
+++ b/src/BiometryService.SampleApp.Uno/BiometryService.SampleApp.Uno.Droid/BiometryService.SampleApp.Uno.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Reactive.Annex.Uno">
-      <Version>0.3.0-feature.uno-ui-4.24</Version>
+      <Version>0.5.0-dev.29</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.0.7" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.7" Condition="'$(Configuration)'=='Debug'" />
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Biometric">
-      <Version>1.1.0.1</Version>
+      <Version>1.1.0.4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -103,7 +103,6 @@
   <Import Project="..\BiometryService.SampleApp.Uno.Shared\BiometryService.SampleApp.Uno.Shared.projitems" Label="Shared" Condition="Exists('..\BiometryService.SampleApp.Uno.Shared\BiometryService.SampleApp.Uno.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- This will force the generation of the APK when not building inside visual studio -->
-  <Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''" />
   <Target Name="Issue3897Workaround" Condition=" '$(ManagedDesignTimeBuild)' == 'True' " AfterTargets="_RemoveLegacyDesigner">
     <!-- See https://github.com/unoplatform/uno/issues/3897 and https://github.com/xamarin/xamarin-android/issues/5069 for more details -->
     <ItemGroup>

--- a/src/BiometryService.SampleApp.Uno/BiometryService.SampleApp.Uno.UWP/BiometryService.SampleApp.Uno.UWP.csproj
+++ b/src/BiometryService.SampleApp.Uno/BiometryService.SampleApp.Uno.UWP/BiometryService.SampleApp.Uno.UWP.csproj
@@ -11,9 +11,9 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="Reactive.Annex">
-      <Version>0.3.0-feature.uno-ui-4.24</Version>
+      <Version>0.5.0-dev.29</Version>
     </PackageReference>
-	  <PackageReference Include="Uno.Core" Version="4.0.1" />
+    <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.UI" Version="4.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
@@ -28,8 +28,8 @@
     <AssemblyName>BiometryService.SampleApp.Uno</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/BiometryService/BiometryService.csproj
+++ b/src/BiometryService/BiometryService.csproj
@@ -6,7 +6,7 @@
 	  e.g. macOS: The specified language targets for uap10.0.17763 is missing. Ensure correct tooling is installed for 'uap'.
 	  -->
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(OSX))' ">netstandard2.0;xamarinios10;</TargetFrameworks>
-    <TargetFrameworks Condition=" '!$([MSBuild]::IsOsPlatform(OSX))' ">netstandard2.0;xamarinios10;monoandroid10.0;uap10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition=" '!$([MSBuild]::IsOsPlatform(OSX))' ">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
     <Authors>nventive</Authors>
     <Company>nventive</Company>
     <RootNamespace>BiometryService</RootNamespace>
@@ -21,18 +21,11 @@
     <PackageReference Include="Uno.UI" Version="4.0.7" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'monoandroid11.0'">
-    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.3" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView " Version="1.1.0.8" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'monoandroid10.0'">
-    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.3" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView " Version="1.1.0.8" />
+  <ItemGroup Condition="'$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='monoandroid12.0'">
+    <PackageReference Include="Xamarin.AndroidX.Biometric" Version="1.1.0.4" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView " Version="1.2.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes
Documentation content changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore


## Other information
