### PR TITLE
fix: change package id name

### DIFF
--- a/Src/BiometryService.Uno.WinUI/BiometryService.Uno.WinUI.csproj
+++ b/Src/BiometryService.Uno.WinUI/BiometryService.Uno.WinUI.csproj
@@ -6,7 +6,7 @@
     <Authors>nventive</Authors>
     <Company>nventive</Company>
     <AssemblyName>BiometryService</AssemblyName>
-    <PackageId>BiometryService</PackageId>
+    <PackageId>BiometryService.Uno.WinUI</PackageId>
     <Description>BiometryService</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>biometry;mvvm;maui;winui;ios;android</PackageTags>

--- a/Src/BiometryService.Uno/BiometryService.Uno.csproj
+++ b/Src/BiometryService.Uno/BiometryService.Uno.csproj
@@ -10,7 +10,7 @@
     <Authors>nventive</Authors>
     <Company>nventive</Company>
     <AssemblyName>BiometryService</AssemblyName>
-    <PackageId>BiometryService</PackageId>
+    <PackageId>BiometryService.Uno</PackageId>
     <Description>BiometryService</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>biometry;mvvm;xamarin;uwp;ios;android</PackageTags>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
change back the package id name for uno and uno.winui

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

